### PR TITLE
Implement Get mentor by id endpoint (Public endpoint)

### DIFF
--- a/src/controllers/mentor.controller.ts
+++ b/src/controllers/mentor.controller.ts
@@ -1,5 +1,9 @@
 import type { Request, Response } from 'express'
-import { createMentor, updateAvailability } from '../services/mentor.service'
+import {
+  createMentor,
+  updateAvailability,
+  getMentor
+} from '../services/mentor.service'
 import type Profile from '../entities/profile.entity'
 
 export const mentorApplicationHandler = async (
@@ -35,6 +39,24 @@ export const mentorAvailabilityHandler = async (
     const { availability } = req.body
     const result = await updateAvailability(user, availability)
     res.status(result.statusCode).json(result.updatedMentorApplication)
+  } catch (err) {
+    if (err instanceof Error) {
+      console.error('Error executing query', err)
+      res
+        .status(500)
+        .json({ error: 'Internal server error', message: err.message })
+    }
+  }
+}
+
+export const mentorDetailsHandler = async (
+  req: Request,
+  res: Response
+): Promise<void> => {
+  try {
+    const mentorId = req.params.mentorId
+    const { mentor, statusCode, message } = await getMentor(mentorId)
+    res.status(statusCode).json({ mentor, message })
   } catch (err) {
     if (err instanceof Error) {
       console.error('Error executing query', err)

--- a/src/controllers/mentor.controller.ts
+++ b/src/controllers/mentor.controller.ts
@@ -56,7 +56,24 @@ export const mentorDetailsHandler = async (
   try {
     const mentorId = req.params.mentorId
     const { mentor, statusCode, message } = await getMentor(mentorId)
-    res.status(statusCode).json({ mentor, message })
+
+    if (!mentor) {
+      res.status(statusCode).json({ error: message })
+    } else {
+      const mentorDetails = {
+        mentorId: mentor.uuid,
+        category: mentor.category.category,
+        profile: {
+          contact_email: mentor.profile.contact_email,
+          first_name: mentor.profile.first_name,
+          last_name: mentor.profile.last_name,
+          image_url: mentor.profile.image_url,
+          linkedin_url: mentor.profile.linkedin_url
+        },
+        mentees: mentor.mentees
+      }
+      res.status(statusCode).json({ mentorDetails, message })
+    }
   } catch (err) {
     if (err instanceof Error) {
       console.error('Error executing query', err)

--- a/src/controllers/mentor.controller.ts
+++ b/src/controllers/mentor.controller.ts
@@ -72,7 +72,7 @@ export const mentorDetailsHandler = async (
         },
         mentees: mentor.mentees
       }
-      res.status(statusCode).json({ mentorDetails, message })
+      res.status(statusCode).json({ ...mentorDetails })
     }
   } catch (err) {
     if (err instanceof Error) {

--- a/src/controllers/mentor.controller.ts
+++ b/src/controllers/mentor.controller.ts
@@ -69,8 +69,7 @@ export const mentorDetailsHandler = async (
           last_name: mentor.profile.last_name,
           image_url: mentor.profile.image_url,
           linkedin_url: mentor.profile.linkedin_url
-        },
-        mentees: mentor.mentees
+        }
       }
       res.status(statusCode).json({ ...mentorDetails })
     }

--- a/src/routes/mentor/mentor.route.test.ts
+++ b/src/routes/mentor/mentor.route.test.ts
@@ -65,6 +65,20 @@ describe('Mentor application', () => {
     })
   })
 
+  describe('Update Mentor Availability', () => {
+    it.each([true, false])(
+      'should update mentor availability and return a 201 with the updated availability',
+      async (availability) => {
+        const response = await agent
+          .put('/api/mentors/me/availability')
+          .send({ availability })
+          .expect(200)
+
+        expect(response.body).toHaveProperty('availability', availability)
+      }
+    )
+  })
+
   describe('Get mentor details route', () => {
     it('should return a 200 with the mentor details', async () => {
       const response = await agent
@@ -81,18 +95,22 @@ describe('Mentor application', () => {
       await agent.get(`/api/mentors/${nonExistentId}`).expect(404)
     })
 
-    describe('Update Mentor Availability', () => {
-      it.each([true, false])(
-        'should update mentor availability and return a 201 with the updated availability',
-        async (availability) => {
-          const response = await agent
-            .put('/api/mentors/me/availability')
-            .send({ availability })
-            .expect(200)
+    it('should return a 200 with the mentor details', async () => {
+      const response = await supertest(server)
+        .get(`/api/mentors/${savedMentor.uuid}`)
+        .expect(200)
 
-          expect(response.body).toHaveProperty('availability', availability)
-        }
-      )
+      expect(response.body).toHaveProperty('mentorId')
+      expect(response.body).toHaveProperty('category')
+      expect(response.body).toHaveProperty('profile')
+    })
+
+    it('should return a 404 when the mentor ID is not found', async () => {
+      const nonExistentId = uuidv4()
+      const response = await supertest(server)
+        .get(`/api/mentors/${nonExistentId}`)
+        .expect(404)
+      expect(response.body).toHaveProperty('error', 'Mentor not found')
     })
 
     afterAll(async () => {

--- a/src/routes/mentor/mentor.route.test.ts
+++ b/src/routes/mentor/mentor.route.test.ts
@@ -74,7 +74,6 @@ describe('Mentor application', () => {
       expect(response.body).toHaveProperty('mentorId')
       expect(response.body).toHaveProperty('category')
       expect(response.body).toHaveProperty('profile')
-      expect(response.body).toHaveProperty('mentees')
     })
 
     it('should return a 404 when the mentor ID is not found', async () => {

--- a/src/routes/mentor/mentor.route.test.ts
+++ b/src/routes/mentor/mentor.route.test.ts
@@ -5,12 +5,14 @@ import { dataSource } from '../../configs/dbConfig'
 import { mentorApplicationInfo, mockUser } from '../../../mocks'
 import { v4 as uuidv4 } from 'uuid'
 import Category from '../../entities/category.entity'
+import type Mentor from '../../entities/mentor.entity'
 
 const port = Math.floor(Math.random() * (9999 - 3000 + 1)) + 3000
 
 let server: Express
 let agent: supertest.SuperAgentTest
 let savedCategory: Category
+let savedMentor: Mentor
 
 describe('Mentor application', () => {
   beforeAll(async () => {
@@ -38,6 +40,7 @@ describe('Mentor application', () => {
 
       expect(response.body).toHaveProperty('mentor')
       expect(response.body).toHaveProperty('message')
+      savedMentor = response.body.mentor
     })
 
     it('should return a 409 when the user is already a mentor or has an pending invitation', async () => {
@@ -59,6 +62,24 @@ describe('Mentor application', () => {
 
     it('should return a 401 when a valid access token is not provided', async () => {
       await supertest(server).post('/api/mentors').send({}).expect(401)
+    })
+  })
+
+  describe('Get mentor details route', () => {
+    it('should return a 200 with the mentor details', async () => {
+      const response = await agent
+        .get(`/api/mentors/${savedMentor.uuid}`)
+        .expect(200)
+
+      expect(response.body).toHaveProperty('mentorId')
+      expect(response.body).toHaveProperty('category')
+      expect(response.body).toHaveProperty('profile')
+      expect(response.body).toHaveProperty('mentees')
+    })
+
+    it('should return a 404 when the mentor ID is not found', async () => {
+      const nonExistentId = uuidv4()
+      await agent.get(`/api/mentors/${nonExistentId}`).expect(404)
     })
 
     describe('Update Mentor Availability', () => {

--- a/src/routes/mentor/mentor.route.ts
+++ b/src/routes/mentor/mentor.route.ts
@@ -2,12 +2,14 @@ import express from 'express'
 import { requireAuth } from './../../controllers/auth.controller'
 import {
   mentorApplicationHandler,
-  mentorAvailabilityHandler
+  mentorAvailabilityHandler,
+  mentorDetailsHandler
 } from './../../controllers/mentor.controller'
 
 const mentorRouter = express.Router()
 
 mentorRouter.post('/', requireAuth, mentorApplicationHandler)
 mentorRouter.put('/me/availability', requireAuth, mentorAvailabilityHandler)
+mentorRouter.get('/:mentorId', mentorDetailsHandler)
 
 export default mentorRouter

--- a/src/services/mentor.service.ts
+++ b/src/services/mentor.service.ts
@@ -102,3 +102,35 @@ export const updateAvailability = async (
     throw new Error('Error creating mentor')
   }
 }
+
+export const getMentor = async (
+  mentorId: string
+): Promise<{
+  statusCode: number
+  mentor?: Mentor | null
+  message: string
+}> => {
+  try {
+    const mentorRepository = dataSource.getRepository(Mentor)
+    const mentor = await mentorRepository.findOne({
+      where: { uuid: mentorId },
+      relations: ['profile', 'category', 'mentees']
+    })
+
+    if (!mentor) {
+      return {
+        statusCode: 404,
+        message: 'Mentor not found'
+      }
+    }
+
+    return {
+      statusCode: 200,
+      mentor,
+      message: 'Mentor found'
+    }
+  } catch (err) {
+    console.error('Error getting mentor', err)
+    throw new Error('Error getting mentor')
+  }
+}


### PR DESCRIPTION
## Purpose
<!--- Describe the problems, issues, or needs driving this feature/fix and include links to related issues -->
The purpose of this PR is to fix #15

## Goals
<!---  Describe the solutions that this feature/fix will introduce to resolve the problems described above -->
This issue involves implementing an API to get mentors by id. The endpoint should allow clients to make a GET request to `{{baseUrl}}/api/mentors/{{mentorId}}`.
```
{
    "mentorId": 5,
    "category": "Computer Science",
    "profile": {
        "contact_email": "mandy@gmail.com",
        "first_name": "Mandy",
        "last_name": "Fernando",
        "image_url": "https://www.linkedin.com/mandy",
        "linkedin_url": "https://www.linkedin.com/mandy"
    },
    "mentees": []
}
```

## Approach
<!--- Describe how you are implementing the solutions. Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here. -->
- Create a controller for the /controllers/mentor endpoint in the backend (create the route mentor if not created).
- Implement appropriate error handling and response status codes for different scenarios (e.g., validation errors, database errors).
- Write unit tests to validate the functionality and correctness of the endpoint.


##  Checklist
- [x] This PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.
- [x] I have read and understood the development best practices guidelines ( http://bit.ly/sef-best-practices )
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation

## Related PRs

## Test environment
<!--- List all versions, operating systems, databases, and browser/versions on which this feature/fix was tested --> 
macOS 13 latest, local Postgres 15 env.
