### PR TITLE
Add get all Mentees by the status

### DIFF
--- a/src/controllers/admin/mentee.controller.ts
+++ b/src/controllers/admin/mentee.controller.ts
@@ -10,7 +10,8 @@ import {
   getAllMenteeEmailsService,
   getAllMentees,
   getMentee,
-  updateStatus
+  updateStatus,
+  getMenteesByStatus
 } from '../../services/admin/mentee.service'
 import type { ApiResponse, PaginatedApiResponse } from '../../types'
 
@@ -144,5 +145,48 @@ export const getAllMenteeEmails = async (
   } catch (err) {
     console.error(err)
     return res.status(500).json({ error: err || 'Internal Server Error' })
+  }
+}
+
+export const getAllMenteesByStatus = async (
+  req: Request,
+  res: Response
+): Promise<ApiResponse<Mentee[]>> => {
+  try {
+    const status = req.query.status as MenteeApplicationStatus
+    const user = req.user as Profile
+
+    if (user.type !== ProfileTypes.ADMIN) {
+      return res.status(403).json({ message: 'Only Admins are allowed' })
+    }
+
+    if (!status) {
+      return res.status(400).json({ message: 'Invalid or missing status parameter' })
+    }
+
+    const validStatuses = Object.values(MenteeApplicationStatus);
+    const lowerCaseStatus = status.toLowerCase() as MenteeApplicationStatus;
+
+    if (!validStatuses.includes(lowerCaseStatus)) {
+      return res.status(400).json({ 
+        message: 'Invalid status provided' 
+      });
+    }
+
+    const { mentees, statusCode, message } = await getMenteesByStatus(status.toLowerCase() as MenteeApplicationStatus)
+
+    return res.status(statusCode).json({
+      mentees,
+      message
+    })
+  } catch (err) {
+    if (err instanceof Error) {
+      console.error('Error fetching mentees by status:', err)
+      return res.status(500).json({ 
+        error: 'Internal server error',
+        message: err.message 
+      })
+    }
+    return res.status(500).json({ error: 'Unexpected server error' })
   }
 }

--- a/src/routes/admin/mentee/mentee.route.ts
+++ b/src/routes/admin/mentee/mentee.route.ts
@@ -3,7 +3,8 @@ import {
   getAllMenteeEmails,
   getMenteeDetails,
   getMentees,
-  updateMenteeStatus
+  updateMenteeStatus,
+  getAllMenteesByStatus
 } from '../../../controllers/admin/mentee.controller'
 import { requireAuth } from '../../../controllers/auth.controller'
 import {
@@ -41,5 +42,7 @@ menteeRouter.put(
   [requireAuth, requestBodyValidator(updateMenteeStatusSchema)],
   updateMenteeStatus
 )
+
+menteeRouter.get('/',requireAuth,getAllMenteesByStatus)
 
 export default menteeRouter

--- a/src/services/admin/mentee.service.test.ts
+++ b/src/services/admin/mentee.service.test.ts
@@ -1,7 +1,7 @@
 import { dataSource } from '../../configs/dbConfig'
 import type Mentee from '../../entities/mentee.entity'
 import { MenteeApplicationStatus } from '../../enums'
-import { getAllMenteeEmailsService, getAllMentees } from './mentee.service'
+import { getAllMenteeEmailsService, getAllMentees,getMenteesByStatus } from './mentee.service'
 
 jest.mock('../../configs/dbConfig', () => ({
   dataSource: {
@@ -191,5 +191,93 @@ describe('Mentee Service', () => {
         getAllMentees({ status, pageNumber: 1, pageSize: 2 })
       ).rejects.toThrowError('Error getting mentees')
     })
+  })
+})
+
+
+
+describe('Mentee Service - getMenteesByStatus', () => {
+  it('should get all mentees by status successfully', async () => {
+    const status: MenteeApplicationStatus = MenteeApplicationStatus.APPROVED
+
+    const mockMentees = [
+      {
+        uuid: 'mock-uuid-1',
+        state: status,
+        profile: {
+          uuid: 'profile-uuid-1',
+          primary_email: 'mentee1@example.com'
+        },
+        mentor: {
+          uuid: 'mentor-uuid-1',
+          profile: {
+            uuid: 'mentor-profile-uuid-1',
+            primary_email: 'mentor1@example.com'
+          }
+        }
+      },
+      {
+        uuid: 'mock-uuid-2',
+        state: status,
+        profile: {
+          uuid: 'profile-uuid-2',
+          primary_email: 'mentee2@example.com'
+        },
+        mentor: {
+          uuid: 'mentor-uuid-2',
+          profile: {
+            uuid: 'mentor-profile-uuid-2',
+            primary_email: 'mentor2@example.com'
+          }
+        }
+      }
+    ] as Mentee[]
+
+    const mockMenteeRepository = {
+      find: jest.fn().mockResolvedValue(mockMentees)
+    }
+
+    ;(dataSource.getRepository as jest.Mock).mockReturnValueOnce(
+      mockMenteeRepository
+    )
+
+    const result = await getMenteesByStatus(status)
+
+    expect(result.statusCode).toBe(200)
+    expect(result.mentees).toEqual(mockMentees)
+    expect(result.message).toBe('Mentees found with the specified status')
+  })
+
+  it('should handle no mentees found with the specified status', async () => {
+    const status: MenteeApplicationStatus = MenteeApplicationStatus.PENDING
+
+    const mockMenteeRepository = {
+      find: jest.fn().mockResolvedValue([])
+    }
+
+    ;(dataSource.getRepository as jest.Mock).mockReturnValueOnce(
+      mockMenteeRepository
+    )
+
+    const result = await getMenteesByStatus(status)
+
+    expect(result.statusCode).toBe(404)
+    expect(result.message).toBe('No mentees found with the specified status')
+  })
+
+  it('should handle error during mentees retrieval', async () => {
+    const status: MenteeApplicationStatus = MenteeApplicationStatus.APPROVED
+
+    const mockMenteeRepository = {
+      find: jest.fn().mockRejectedValue(new Error('Test repository error'))
+    }
+
+    ;(dataSource.getRepository as jest.Mock).mockReturnValueOnce(
+      mockMenteeRepository
+    )
+
+    await expect(getMenteesByStatus(status)).rejects.toThrowError(
+      'Error fetching mentees by status'
+    )
   })
 })

--- a/src/services/admin/mentee.service.ts
+++ b/src/services/admin/mentee.service.ts
@@ -280,3 +280,37 @@ export const revoke = async (
     throw new Error('Error updating mentee status')
   }
 }
+
+
+export const getMenteesByStatus = async (
+  status: MenteeApplicationStatus
+): Promise<{
+  statusCode: number
+  mentees?: Mentee[]
+  message: string
+}> => {
+  try {
+    const menteeRepository = dataSource.getRepository(Mentee)
+
+    const mentees = await menteeRepository.find({
+      where: { state: status },
+      relations: ['profile', 'mentor']
+    })
+
+    if (mentees.length === 0) {
+      return {
+        statusCode: 404,
+        message: 'No mentees found with the specified status'
+      }
+    }
+
+    return {
+      statusCode: 200,
+      mentees,
+      message: 'Mentees found with the specified status'
+    }
+  } catch (err) {
+    console.error('Error fetching mentees by status:', err)
+    throw new Error('Error fetching mentees by status')
+  }
+}


### PR DESCRIPTION
## Purpose
In this issue number 31 mention "Implement all mentees by status endpoint for the Admin".
The purpose of this PR is to fix #31 

## Goals
In this feature, i will create a endpoint for fetch that all data by status, in the admin service. and also implement the test cases for that feature.

## Approach
In here i will implement method call getMenteesByStatus in mentee.controller.ts file inside the controllers/admin. and also implement services method call getMenteesByStatus inside the mentee.service.ts inside the services/admin. 
So after implementing the feature methods, write test file in the mentee.service.test.ts to ensure all the funationalities work as expected.



